### PR TITLE
Remove ACL

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -6,11 +6,6 @@ resource "aws_s3_bucket" "storage" {
   bucket = "spacelift-events-${random_string.suffix.result}"
 }
 
-resource "aws_s3_bucket_acl" "storage" {
-  acl    = "private"
-  bucket = aws_s3_bucket.storage.id
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "cleanup" {
   bucket = aws_s3_bucket.storage.id
 


### PR DESCRIPTION
I received an error from the ACL resource. I believe this is due to [AWS disabling ACLs for all new buckets as of April 5 2023](https://aws.amazon.com/about-aws/whats-new/2023/04/amazon-s3-two-security-best-practices-buckets-default/).

```
│ Error: error creating S3 bucket ACL for spacelift-events-isia942y: AccessControlListNotSupported: The bucket does not allow ACLs
│ 	status code: 400, request id: 4VTHP4921CHMHWCC, host id: rYjIKd/1nXATNpg7DoU4z86oS1NlpOkS9r4m8odoEtcydyCJ13djHWF3wD6idSZQnfudN/6W7uo=
│ 
│   with module.collector.aws_s3_bucket_acl.storage,
│   on .terraform/modules/collector/s3.tf line 9, in resource "aws_s3_bucket_acl" "storage":
│    9: resource "aws_s3_bucket_acl" "storage" {
│ 
```

