### PR TITLE
Upgrade to AWS provider 5.0.0 (solves unsupported arguments for aws_kinesis_firehose_delivery_stream resource)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ The main resources for this module are:
 | Name | Version |
 |------|---------|
 | archive | ~> 2.2 |
-| aws | >= 4.9.0 |
+| aws | >= 5.0.0 |
 | random | ~> 3.1 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| buffer\_interval | Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination | `number` | `300` | no |
-| buffer\_size | Buffer incoming events to the specified size, in MBs, before delivering it to the destination | `number` | `5` | no |
+| buffering\_interval | Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination | `number` | `300` | no |
+| buffering\_size | Buffer incoming events to the specified size, in MBs, before delivering it to the destination | `number` | `5` | no |
 | delete\_events\_when\_destroying\_stack | Whether to delete stored events when destroying the stack | `bool` | `false` | no |
 | events\_expiration\_days | Keep the events for this number of days | `number` | `365` | no |
 | logs\_retention\_days | Keep the logs for this number of days | `number` | `14` | no |

--- a/main.tf
+++ b/main.tf
@@ -104,8 +104,8 @@ resource "aws_kinesis_firehose_delivery_stream" "stream" {
   name        = local.stream_name
 
   extended_s3_configuration {
-    buffer_interval     = var.buffer_interval
-    buffer_size         = var.buffer_size
+    buffering_interval  = var.buffering_interval
+    buffering_size      = var.buffering_size
     bucket_arn          = aws_s3_bucket.storage.arn
     error_output_prefix = "error/!{firehose:error-output-type}/"
     compression_format  = "GZIP"

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,10 @@
-variable "buffer_interval" {
+variable "buffering_interval" {
   default     = 300
   description = "Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination"
   type        = number
 }
 
-variable "buffer_size" {
+variable "buffering_size" {
   default     = 5
   description = "Buffer incoming events to the specified size, in MBs, before delivering it to the destination"
   type        = number

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0"
+      version = ">= 5.0.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
I also ran into the currently open issue ([Error: Unsupported arguments for aws_kinesis_firehose_delivery_stream resource](https://github.com/spacelift-io-examples/terraform-aws-spacelift-events-collector/issues/4)). For this project the relevant breaking change occurred in the AWS provider upgrade to `5.0.0` and requires a couple variable name updates to get on `5.0.0` (recognizing that these var name updates won't be backwards compatible). 