### PR TITLE
Allows updates to AWS lambda python runtime version

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The main resources for this module are:
 | events\_expiration\_days | Keep the events for this number of days | `number` | `365` | no |
 | logs\_retention\_days | Keep the logs for this number of days | `number` | `14` | no |
 | logs\_verbose | Include debug information in the logs | `bool` | `false` | no |
+| python\_version | AWS Lambda Python runtime version | `string` | `"3.9"` | no |
 | secret | Secret to be expected by the collector | `string` | `""` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "aws_lambda_function" "courier" {
   function_name    = local.courier_name
   handler          = "function.handler"
   role             = aws_iam_role.courier.arn
-  runtime          = "python3.9"
+  runtime          = "python${var.python_version}"
   source_code_hash = data.archive_file.lambda_function.output_base64sha256
 
   environment {

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,12 @@ variable "logs_verbose" {
   type        = bool
 }
 
+variable "python_version" {
+  default     = "3.9"
+  description = "AWS Lambda Python runtime version"
+  type        = string
+}
+
 variable "secret" {
   default     = ""
   description = "Secret to be expected by the collector"


### PR DESCRIPTION

### What?
Allows updates to AWS lambda python runtime version without a module version update 

### Why?
Allows users to stay up to date on python versions for security reasons. 