### PR TITLE
Update function.py

### DIFF
--- a/function.py
+++ b/function.py
@@ -6,7 +6,7 @@ import os
 
 def is_signature_valid(headers, payload, secret):
   signature = hmac.new(secret.encode("UTF-8"), payload.encode("UTF-8"), hashlib.sha256).hexdigest()
-  return hmac.compare_digest(f"sha256={signature}", headers["x-signature-256"])
+  return hmac.compare_digest(f"sha256={signature}", headers["X-Signature-256"])
 
 def handler(event, context):
   if os.getenv("VERBOSE") == "true":


### PR DESCRIPTION
Modified the is_signature_valid function definition in function.py. The header coming from Spacelift has 'X-Signature-256'. The code uses ''x-signature-256' which doesn't exist in the Spacelift Header.
Not Resolving this would cause API Error on Spacelift and KeyError:'x-signature-256' on AWS(Lambda Logs). 